### PR TITLE
fix: add dune-build-info to dune-project

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -20,6 +20,7 @@ merlin for accurate symbol analysis across dune projects.")
  (depends
   (ocaml (>= 5.3))
   dune
+  dune-build-info
   merlin
   (yojson (>= 1.6))
   (bos (>= 0.2))


### PR DESCRIPTION
This is a required library by the main `prune` binary and lives in the `dune-build-info` package.

fix #3 